### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -56,7 +56,7 @@ $(document).on('turbolinks:load',function() {
 
   var reloadMessages = function() {
     if(window.location.href.match(/\/groups\/\d+\/messages/)) {
-      group_id = window.location.href.match(/groups\/(\d)/)[1];
+      group_id = window.location.href.match(/groups\/(\d+)/)[1];
       //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
       last_message_id = $('.message:last').data('id');
       $.ajax({

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -21,6 +21,12 @@ $(document).on('turbolinks:load',function(){
     $('.new-message__submit-btn').attr('disabled',false);
   }
 
+  function createNewMessage(message) {
+    $('.messages').append(message);
+    var position = $('.messages')[0].scrollHeight;
+    $('.messages').animate({scrollTop:position}, 500, 'swing');
+  }
+
   $('#new-message').on('submit', function(e) {
     e.preventDefault();
     var formData = new FormData(this);

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load',function(){
+$(document).on('turbolinks:load',function() {
   function buildHTML(message) {
     image = ( message.image ) ? `<img src="${message.image}">` : "";
     var html = `<div class="message" data-id="${message.id}">
@@ -16,7 +16,7 @@ $(document).on('turbolinks:load',function(){
     return html;
   }
 
-  function resetSendBTN(){
+  function resetSendBTN() {
     $('#new-message')[0].reset();
     $('.new-message__submit-btn').attr('disabled',false);
   }
@@ -49,7 +49,7 @@ $(document).on('turbolinks:load',function(){
       alert('メッセージを入力してください。');
     })
 
-    .always(function(){
+    .always(function() {
       resetSendBTN();
     });
   });

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -84,7 +84,7 @@ $(document).on('turbolinks:load',function() {
       })
 
       .fail(function() {
-        console.log('error');
+        alert('エラー');
       });
     }
   };

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -51,5 +51,7 @@ $(document).on('turbolinks:load',function(){
   });
 
   var reloadMessages = function() {
+    if(window.location.href.match(/\/groups\/\d+\/messages/)) {
+  };
 
 });

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -65,6 +65,10 @@ $(document).on('turbolinks:load',function(){
         data: { id: last_message_id }
       })
 
+      .done(function(messages) {
+        if (messages.slice(-1)[0].id){
+        }
+      })
   };
 
 });

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -4,7 +4,7 @@ $(document).on('turbolinks:load',function(){
     var html = `<div class="message" data-id="${message.id}">
                   <div class="upper-info clearfix">
                     <p class="upper-info__user">
-                      ${message.name}
+                      ${message.user_name}
                     </p>
                     <p class="upper-info__date">
                       ${message.created_at}

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -52,6 +52,7 @@ $(document).on('turbolinks:load',function(){
 
   var reloadMessages = function() {
     if(window.location.href.match(/\/groups\/\d+\/messages/)) {
+      group_id = window.location.href.match(/groups\/(\d)/)[1];
   };
 
 });

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -42,9 +42,7 @@ $(document).on('turbolinks:load',function(){
 
     .done(function(data) {
       var html = buildHTML(data);
-      $('.messages').append(html);
-      var position = $('.messages')[0].scrollHeight;
-      $('.messages').animate({scrollTop:position}, 500, 'swing');
+      createNewMessage(html);
     })
 
     .fail(function() {

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -82,6 +82,11 @@ $(document).on('turbolinks:load',function(){
           createNewMessage(insertHTML);
         }
       })
+
+      .fail(function() {
+        console.log('error');
+      });
+    }
   };
 
 });

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -74,6 +74,8 @@ $(document).on('turbolinks:load',function(){
             //メッセージが入ったHTMLを取得
             insertHTML += buildHTML(message);
           });
+          //メッセージを追加
+          createNewMessage(insertHTML);
         }
       })
   };

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -89,4 +89,5 @@ $(document).on('turbolinks:load',function(){
     }
   };
 
+  setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -55,6 +55,16 @@ $(document).on('turbolinks:load',function(){
       group_id = window.location.href.match(/groups\/(\d)/)[1];
       //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
       last_message_id = $('.message:last').data('id');
+      $.ajax({
+        //ルーティングで設定した通りのURLを指定
+        url: `/groups/${group_id}/api/messages`,
+        //ルーティングで設定した通りhttpメソッドをgetに指定
+        type: 'get',
+        dataType: 'json',
+        //dataオプションでリクエストに値を含める
+        data: { id: last_message_id }
+      })
+
   };
 
 });

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -1,7 +1,7 @@
 $(document).on('turbolinks:load',function(){
   function buildHTML(message) {
     image = ( message.image ) ? `<img src="${message.image}">` : "";
-    var html = `<div class="message">
+    var html = `<div class="message" data-id="${message.id}">
                   <div class="upper-info clearfix">
                     <p class="upper-info__user">
                       ${message.name}

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -67,6 +67,13 @@ $(document).on('turbolinks:load',function(){
 
       .done(function(messages) {
         if (messages.slice(-1)[0].id){
+          //追加するHTMLの入れ物を作る
+          var insertHTML = '';
+          //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+          messages.forEach(function(message) {
+            //メッセージが入ったHTMLを取得
+            insertHTML += buildHTML(message);
+          });
         }
       })
   };

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -53,6 +53,8 @@ $(document).on('turbolinks:load',function(){
   var reloadMessages = function() {
     if(window.location.href.match(/\/groups\/\d+\/messages/)) {
       group_id = window.location.href.match(/groups\/(\d)/)[1];
+      //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+      last_message_id = $('.message:last').data('id');
   };
 
 });

--- a/app/assets/javascripts/send_message.js
+++ b/app/assets/javascripts/send_message.js
@@ -49,4 +49,7 @@ $(document).on('turbolinks:load',function(){
       resetSendBTN();
     });
   });
+
+  var reloadMessages = function() {
+
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -4,6 +4,11 @@ class Api::MessagesController < ApplicationController
   def index
     # 送られてきたIDから最新のIDまでを取得させる
     @messages = @group.messages.includes(:user).where("id > ?", params[:id])
+    respond_to do |format|
+      format.json
+    end
+  end
+
   def set_group
     @group = Group.find(params[:group_id])
   end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,2 +1,6 @@
 class Api::MessagesController < ApplicationController
+  def index
+    # 送られてきたIDから最新のIDまでを取得させる
+    @messages = @group.messages.includes(:user).where("id > ?", params[:id])
+  end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,6 +1,10 @@
 class Api::MessagesController < ApplicationController
+  before_action :set_group
+
   def index
     # 送られてきたIDから最新のIDまでを取得させる
     @messages = @group.messages.includes(:user).where("id > ?", params[:id])
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,2 @@
+class Api::MessagesController < ApplicationController
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.to_s
+  json.user_name message.user.name
+  json.created_at message.created_at.strftime('%Y/%m/%d(%a)%H:%M:%S')
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{ data: {id: "#{message.id}"}}
   .upper-info.clearfix
     %p.upper-info__user= message.user.name
     %p.upper-info__date= message.created_at.strftime('%Y/%m/%d(%a)%H:%M:%S')

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.content @message.content
 json.image @message.image.to_s
-json.name @message.user.name
+json.user_name @message.user.name
 json.created_at @message.created_at.strftime('%Y/%m/%d(%a)%H:%M:%S')
 json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content @message.content
 json.image @message.image.to_s
 json.name @message.user.name
 json.created_at @message.created_at.strftime('%Y/%m/%d(%a)%H:%M:%S')
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users,  only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# WHAT
クライアントが閲覧しているチャット画面のメッセージを、非同期通信を用いて最新のメッセージが表示される状態に更新する。

# WHY
別のユーザが投稿したメッセージが、自分のチャット画面で表示されないと、会話が成り立たない為。

コメントの送信
![自動更新コメント送信](https://user-images.githubusercontent.com/48540482/57287501-9f636a80-70f2-11e9-84f5-626ae9079181.gif)

画像の送信
![自動更新画像の送信](https://user-images.githubusercontent.com/48540482/57287503-a5594b80-70f2-11e9-82dc-7e1ec144288e.gif)
